### PR TITLE
NIAD-2542: add diagnostic report mapping

### DIFF
--- a/diagnostic reports/README.md
+++ b/diagnostic reports/README.md
@@ -33,55 +33,55 @@ and `CompoundStatement / code [@code]` equals `"16488004"` (laboratory reporting
 ```JSON
 
 {
-    "resource": {
-        "resourceType": "DiagnosticReport",
-        "id": "5A8B9936-B771-488E-9103-3331629690C4",
-        "meta": {
-            "profile": [
-                "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-DiagnosticReport-1"
-            ]
-        },
-        "identifier": [
-            {
-                "system": "https://PSSAdaptor/D5445",
-                "value": "5A8B9936-B771-488E-9103-3331629690C4"
-            },
-            {
-                "system": "2.16.840.1.113883.2.1.4.5.5",
-                "value": "1013/HA2101109A/200203301621"
-            }
-        ],
-        "status": "unknown",
-        "code": {
-            "coding": [
-                {
-                    "system": "http://snomed.info/sct",
-                    "code": "721981007",
-                    "display": "Diagnostic studies report"
-                }
-            ]
-        },
-        "subject": {
-            "reference": "Patient/80bd1375-a1e3-4137-95ff-fb3316cf3496"
-        },
-        "context": {
-            "reference": "Encounter/C5323AB7-2CA9-4E85-85E4-8FA896E45628"
-        },
-        "issued": "2010-06-24T10:34:01.000+00:00",
-        "specimen": [
-            {
-                "reference": "Specimen/73A3DD99-861F-45E3-B7BB-30F71A74AE85"
-            }
-        ],
-        "result": [
-            {
-                "reference": "Observation/F022B5F4-66E8-4DDD-ABAA-10C98713E7EE"
-            },
-            {
-                "reference": "Observation/92DA878D-2346-488E-8742-01ECDE95E31C"
-            }
-        ]
+ "resource": {
+  "resourceType": "DiagnosticReport",
+  "id": "5A8B9936-B771-488E-9103-3331629690C4",
+  "meta": {
+   "profile": [
+    "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-DiagnosticReport-1"
+   ]
+  },
+  "identifier": [
+   {
+    "system": "https://PSSAdaptor/D5445",
+    "value": "5A8B9936-B771-488E-9103-3331629690C4"
+   },
+   {
+    "system": "2.16.840.1.113883.2.1.4.5.5",
+    "value": "1013/HA2101109A/200203301621"
+   }
+  ],
+  "status": "unknown",
+  "code": {
+   "coding": [
+    {
+     "system": "http://snomed.info/sct",
+     "code": "721981007",
+     "display": "Diagnostic studies report"
     }
+   ]
+  },
+  "subject": {
+   "reference": "Patient/80bd1375-a1e3-4137-95ff-fb3316cf3496"
+  },
+  "context": {
+   "reference": "Encounter/C5323AB7-2CA9-4E85-85E4-8FA896E45628"
+  },
+  "issued": "2010-06-24T10:34:01.000+00:00",
+  "specimen": [
+   {
+    "reference": "Specimen/73A3DD99-861F-45E3-B7BB-30F71A74AE85"
+   }
+  ],
+  "result": [
+   {
+    "reference": "Observation/F022B5F4-66E8-4DDD-ABAA-10C98713E7EE"
+   },
+   {
+    "reference": "Observation/92DA878D-2346-488E-8742-01ECDE95E31C"
+   }
+  ]
+ }
 }
 ```
 </details>
@@ -197,34 +197,35 @@ The FHIR Diagnostic Report resource is mapped to a HL7 Compound Statement with a
 ```XML
 
 <CompoundStatement classCode="CLUSTER" moodCode="EVN">
-    <id root="74F2D322-9032-4ED2-999D-0AACA87B3BC8"/>
-    <id extension="1013/HA2101105W/200203301621" root="2.16.840.1.113883.2.1.4.5.5"/>
-    <code code="16488004" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="laboratory reporting">
-        <originalText>Filed Report</originalText>
-    </code>
-    <statusCode code="COMPLETE"/>
-    <effectiveTime>
-        <center nullFlavor="NI"/>
-    </effectiveTime>
-    <availabilityTime value="20020330162100"/>
-    <component contextConductionInd="true" typeCode="COMP">
-        <NarrativeStatement classCode="OBS" moodCode="EVN">
-            <id root="E8F624FF-9364-42BB-9E01-8D3512BBE732"/>
-            <text mediaType="text/x-h7uk-pmip">CommentType:LABORATORY RESULT COMMENT(E141)
+ <id root="74F2D322-9032-4ED2-999D-0AACA87B3BC8"/>
+ <id extension="1013/HA2101105W/200203301621" root="2.16.840.1.113883.2.1.4.5.5"/>
+ <code code="16488004" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="laboratory reporting">
+  <originalText>Filed Report</originalText>
+ </code>
+ <statusCode code="COMPLETE"/>
+ <effectiveTime>
+  <center nullFlavor="NI"/>
+ </effectiveTime>
+ <availabilityTime value="20020330162100"/>
+ <component contextConductionInd="true" typeCode="COMP">
+  <NarrativeStatement classCode="OBS" moodCode="EVN">
+   <id root="E8F624FF-9364-42BB-9E01-8D3512BBE732"/>
+   <text mediaType="text/x-h7uk-pmip">CommentType:LABORATORY RESULT COMMENT(E141)
 CommentDate:20020330162100
 
-Interpretation: ON AZATHIOPRINE</text>
-            <statusCode code="COMPLETE"/>
-            <availabilityTime value="20020330162100"/>
-        </NarrativeStatement>
-    </component>
-    <component contextConductionInd="true" typeCode="COMP">
-        <CompoundStatement classCode="CLUSTER" moodCode="EVN">
-            
-            ...
-            
-        </CompoundStatement>
-    </component>
+Interpretation: ON AZATHIOPRINE
+   </text>
+   <statusCode code="COMPLETE"/>
+   <availabilityTime value="20020330162100"/>
+  </NarrativeStatement>
+ </component>
+ <component contextConductionInd="true" typeCode="COMP">
+  <CompoundStatement classCode="CLUSTER" moodCode="EVN">
+
+   ...
+
+  </CompoundStatement>
+ </component>
 </CompoundStatement>
 ```
 </details>
@@ -309,10 +310,10 @@ The FHIR Specimen resource is mapped to a HL7 Compound Statement with a code of 
   <NarrativeStatement classCode="OBS" moodCode="EVN">
    <id root="DF0FEFF0-32C1-4BB9-8DDD-76E2D13B5D0F"/>
    <text mediaType="text/x-h7uk-pmip">CommentType:LAB SPECIMEN COMMENT(E271)
-    CommentDate:20030627000000
+CommentDate:20030627000000
 
-    Quantity: 1750.000 mL
-    Received Date: 2003-06-27 18:24
+Quantity: 1750.000 mL
+Received Date: 2003-06-27 18:24
    </text>
    <statusCode code="COMPLETE"/>
    <availabilityTime value="20030628112300"/>

--- a/diagnostic reports/README.md
+++ b/diagnostic reports/README.md
@@ -1,0 +1,373 @@
+# Diagnostic Report Mapping
+
+## XML HL7 > JSON FHIR
+
+### Diagnostic Report (XML > JSON)
+
+FHIR Diagnostic Reports are mapped from HL7 Compound Statements where `CompoundStatement [@classCode]` equals `"CLUSTER"`
+and `CompoundStatement / code [@code]` equals `"16488004"` (laboratory reporting).  
+
+| Mapped to (JSON FHIR DiagnosticReport field) | Mapped from (XML HL7 / other source)                                                                                                                                                                                                                                                                         |
+|----------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| id                                           | `CompoundStatement / id[0] [@root]`                                                                                                                                                                                                                                                                          |
+| meta.profile\[0]                             | fixed value = `"https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-DiagnosticReport-1"`                                                                                                                                                                                                            |
+| identifier\[0].system                        | `"https://PSSAdaptor/{{odsCode}}` where `{{odsCode}}` is the ODS Code of the losing practice                                                                                                                                                                                                                 |
+| identifier\[0].value                         | `CompoundStatement / id[0] [@root]`                                                                                                                                                                                                                                                                          |
+| identifier\[1].system                        | fixed value = `"2.16.840.1.113883.2.1.4.5.5"` <sup>1</sup>                                                                                                                                                                                                                                                   |
+| identifier\[1].value                         | `CompoundStatement / id[1] [@root]` <sup>1</sup>                                                                                                                                                                                                                                                             |
+| status                                       | fixed value = `"unknown"`                                                                                                                                                                                                                                                                                    |
+| code.coding\[0].code                         | fixed value =  `"721981007"`                                                                                                                                                                                                                                                                                 |
+| code.coding\[0].system                       | fixed value = `"http://snomed.info/sct"`                                                                                                                                                                                                                                                                     |
+| code.coding\[0].display                      | fixed value = `"Diagnostic studies report"`                                                                                                                                                                                                                                                                  |
+| subject.reference                            | reference to the mapped [Patient](../patient/README.md)                                                                                                                                                                                                                                                      | 
+| context.reference                            | reference to the accociated [Encounter](../encounters/README.md)                                                                                                                                                                                                                                             |
+| issued                                       | `CompoundStatement /availabilityTime [@value]` or else `ehrComposition / author / time [@value]` or else `EhrExtract / availabilityTime [@value]`                                                                                                                                                            |
+| specimen.reference                           | reference to the [Specimen(s)](#Specimen-(XML->-JSON)) the results are based on                                                                                                                                                                                                                              |
+| result\[index].reference                     | reference to the associated Observations, either [Test Result Header](../observations/README.md#Test-Group-Header-(XML-HL7->-JSON-FHIR)), [Test Result](../observations/README.md#Test-Result-(XML-HL7->-JSON-FHIR)) or [Test Report Filing](../observations/README.md#Filing-Comment-(XML-HL7->-JSON-FHIR)) |
+| conclusion                                   | `CompoundStatement / component / NarrativeStatement / text` <sup>2</sup>                                                                                                                                                                                                                                     |
+
+
+<details>
+    <summary>Example JSON</summary>
+
+```JSON
+
+{
+    "resource": {
+        "resourceType": "DiagnosticReport",
+        "id": "5A8B9936-B771-488E-9103-3331629690C4",
+        "meta": {
+            "profile": [
+                "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-DiagnosticReport-1"
+            ]
+        },
+        "identifier": [
+            {
+                "system": "https://PSSAdaptor/D5445",
+                "value": "5A8B9936-B771-488E-9103-3331629690C4"
+            },
+            {
+                "system": "2.16.840.1.113883.2.1.4.5.5",
+                "value": "1013/HA2101109A/200203301621"
+            }
+        ],
+        "status": "unknown",
+        "code": {
+            "coding": [
+                {
+                    "system": "http://snomed.info/sct",
+                    "code": "721981007",
+                    "display": "Diagnostic studies report"
+                }
+            ]
+        },
+        "subject": {
+            "reference": "Patient/80bd1375-a1e3-4137-95ff-fb3316cf3496"
+        },
+        "context": {
+            "reference": "Encounter/C5323AB7-2CA9-4E85-85E4-8FA896E45628"
+        },
+        "issued": "2010-06-24T10:34:01.000+00:00",
+        "specimen": [
+            {
+                "reference": "Specimen/73A3DD99-861F-45E3-B7BB-30F71A74AE85"
+            }
+        ],
+        "result": [
+            {
+                "reference": "Observation/F022B5F4-66E8-4DDD-ABAA-10C98713E7EE"
+            },
+            {
+                "reference": "Observation/92DA878D-2346-488E-8742-01ECDE95E31C"
+            }
+        ]
+    }
+}
+```
+</details>
+
+1. Only where `CompoundStatement / id[1] [@root]` equals `"2.16.840.1.113883.2.1.4.5.5"`, otherwise not mapped. 
+2. Only if the EDIFACT comment type is `LABORATORY RESULT COMMENT(E141)`, otherwise not mapped.
+
+#### Unmapped fields
+The adaptor is not currently mapping the following Diagnostic Report fields: 
+
+- basedOn
+- category
+- performer
+- codedDiagnosis
+
+### Specimen (XML > JSON)
+
+A Specimen is mapped from HL7 `CompoundStatement` where it is a **child component** of a `CompoundStatement`with code 
+`16488004` (laboratory reporting).    
+
+| Mapped to (JSON FHIR Specimen field) | Mapped from (XML HL7 / other source)                                                          |
+|--------------------------------------|-----------------------------------------------------------------------------------------------|
+| id                                   | `CompoundStatement / id [@root]`                                                              |
+| meta.profile[0]                      | fixed value = `"https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Specimen-1"`     |
+| identifier[0].system                 | `"https://PSSAdaptor/{{odsCode}}"` - where {{odsCode}} is the ODS code of the losing practice |
+| identifier[0].value                  | `CompoundStatement / id [@root]`                                                              |
+| accessionIdentifier.value            | `CompoundStatement / specimen[0] / specimenRole / id[1] [@extension]`                         |
+| type.text                            | `CompoundStatement / specimen[0] / specimenRole / specimenSpecimenMaterial / desc`            | 
+| subject.reference                    | reference to the mapped [Patient](../patient/README.md)                                       |
+| collection.collectedDateTime         | `CompoundStatement / specimen[0] / specimenRole / effectiveTime / center [@value]`            |
+| note[0].text                         | `CompoundStatement / component / NarrativeStatement / text` <sup>3</sup>                      |
+
+
+<details>
+    <summary>Example JSON</summary>
+
+```JSON
+
+{
+  "resource": {
+    "resourceType": "Specimen",
+    "id": "73A3DD99-861F-45E3-B7BB-30F71A74AE85",
+    "meta": {
+      "profile": [
+        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Specimen-1"
+      ]
+    },
+    "identifier": [
+      {
+        "system": "https://PSSAdaptor/D5445",
+        "value": "73A3DD99-861F-45E3-B7BB-30F71A74AE85"
+      }
+    ],
+    "accessionIdentifier": {
+      "value": "HA2101109A"
+    },
+    "type": {
+      "text": "VENOUS BLOOD"
+    },
+    "subject": {
+      "reference": "Patient/80bd1375-a1e3-4137-95ff-fb3316cf3496"
+    },
+    "collection": {
+      "collectedDateTime": "2003-01-09"
+    },
+    "note": [
+      {
+        "text": "Some Test Specimen Comment"
+      }
+    ]
+  }
+}
+```
+</details>
+
+3. Where there is more than one Narrative Statement, the text will be concatenated into one note, seperated by newlines.
+
+#### Unmapped fields
+The adaptor is not currently mapping the following Specimen fields:
+
+- status
+- receivedTime
+- collection.extension
+- collection.collector
+- collection.quantity
+- collection.bodysite
+
+## JSON FHIR > XML HL7
+
+### Diagnostic Report (JSON > HL7)
+The FHIR Diagnostic Report resource is mapped to a HL7 Compound Statement with a code of `16488004` (laboratory reporting)
+
+| Mapped to (XML HL7 CompoundStatement element) | Mapped from (JSON FHIR / other source )                                                                                                               |
+|-----------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|
+| id\[0] [@root]                                | Unique ID generated by the adaptor                                                                                                                    |
+| id\[1] [@extension]                           | `DiagnosticReport.identifier[index].value` where `DiagnosticReport.identifier[index].system` equals `"2.16.840.1.113883.2.1.4.5.5"`                   |
+| id\[1] [@root]                                | fixed value = `"2.16.840.1.113883.2.1.4.5.5"`                                                                                                         |
+| code [@code]                                  | fixed value = `"16488004"`                                                                                                                            |
+| code [@codeSystem]                            | fixed value = `"2.16.840.1.113883.2.1.3.2.4.15"`                                                                                                      |
+| code [@displayName]                           | fixed value = `"laboratory reporting"`                                                                                                                |
+| code / originalText                           | fixed value = `"Filed Report"`                                                                                                                        |
+| statusCode [@code]                            | fixed value = `"COMPLETE"`                                                                                                                            |                                                                                                          
+| effectiveTime / center [@nullFlavor]          | fixed value = `"NI"`                                                                                                                                  |
+| availabilityTime [@value]                     | `DiagnosticReport.issued`                                                                                                                             |
+| component / NarrativeStatement                | the mapped [diagnostic report level Narrative Statements](#Diagnostic-Report-Level-Narrative-Statements)                                              |
+| component / CompoundStatement                 | the mapped [Specimens](#Specimen-(JSON->-HL7)) referenced by the `DiagnosticReport.specimen` array <sup>4</sup>                                       |
+| Participant [@typeCode]                       | fixed value = `"AUT"`                                                                                                                                 |
+| Participant / agentRef / id [@root]           | The mapped [Practitioner](../practioners/README.md) or [Organisation](../organisations/README.md) referenced by `DiagnosticReport.performer[0].actor` |
+
+<details>
+    <summary>Example XML</summary>
+
+```XML
+
+<CompoundStatement classCode="CLUSTER" moodCode="EVN">
+    <id root="74F2D322-9032-4ED2-999D-0AACA87B3BC8"/>
+    <id extension="1013/HA2101105W/200203301621" root="2.16.840.1.113883.2.1.4.5.5"/>
+    <code code="16488004" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="laboratory reporting">
+        <originalText>Filed Report</originalText>
+    </code>
+    <statusCode code="COMPLETE"/>
+    <effectiveTime>
+        <center nullFlavor="NI"/>
+    </effectiveTime>
+    <availabilityTime value="20020330162100"/>
+    <component contextConductionInd="true" typeCode="COMP">
+        <NarrativeStatement classCode="OBS" moodCode="EVN">
+            <id root="E8F624FF-9364-42BB-9E01-8D3512BBE732"/>
+            <text mediaType="text/x-h7uk-pmip">CommentType:LABORATORY RESULT COMMENT(E141)
+CommentDate:20020330162100
+
+Interpretation: ON AZATHIOPRINE</text>
+            <statusCode code="COMPLETE"/>
+            <availabilityTime value="20020330162100"/>
+        </NarrativeStatement>
+    </component>
+    <component contextConductionInd="true" typeCode="COMP">
+        <CompoundStatement classCode="CLUSTER" moodCode="EVN">
+            
+            ...
+            
+        </CompoundStatement>
+    </component>
+</CompoundStatement>
+```
+</details>
+
+4. A `component / CompoundStatement` is created for each `Specimen` referenced in the array 
+
+### Diagnostic Report Level Narrative Statements
+
+Narrative Statements are created to preserve data from FHIR fields that have no direct mapping.
+
+| Mapped to (XML HL7 NarrativeStatement element) | Mapped from (JSON FHIR / other source ) |
+|------------------------------------------------|-----------------------------------------|
+| id [@root]                                     | Unique ID generated by the adaptor      |
+| text [@mediaType]                              | fixed value = "text/x-h7uk-pmip"        |
+| text                                           | EDIFACT comment, as described below     |
+| statusCode                                     | fixed value = `"COMPLETE"`              |
+| availabilityTime [@value]                      | `DiagnosticReport.issued`               |
+
+#### Text Element Mapping
+
+ Narrative Statements are created in relation to each of the FHIR Fields / Logical Reasons below. The value of the field 
+ is mapped to the Narrative Statement's `text` element as EDIFACT comment (see example in the XML above), the comment type 
+ of which is shown in the table:
+
+| FHIR field / logical reason                                                                                                                                                                | EDIFACT Comment Type                                    |
+|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------|
+| `diagnosticReport.conclusion`                                                                                                                                                              | `LABORATORY RESULT COMMENT(E141)`                       |
+| concatenated from `dianosticReport.codedDiagnosis`                                                                                                                                         | `LABORATORY RESULT COMMENT(E141)`                       |
+| `dianosticReport.status`                                                                                                                                                                   | `LABORATORY RESULT COMMENT(E141)`                       |
+| none of the fields above are populated and `dianosticReport.result` is missing                                                                                                             | `AGGREGATE COMMENT SET` and fixed body = `EMPTY REPORT` |
+| `Observation.EffectiveDateTime` or `Observation.EffectivePeriod` where the Observation <br/> is a referenced in `dianosticReport.result` and the first Observation coded as `Comment note` | `AGGREGATE COMMENT SET`                                 |
+| Concatenated from `diagnosticReport.performer[index].name`                                                                                                                                 | `AGGREGATE COMMENT SET`                                 |
+| Concatenated from each `Observation.comment` where the Observation is referenced in <br/> `dianosticReport.result` and coded as a comment note                                             | `AGGREGATE_COMMENT_SET`                                 |
+
+### Specimen (JSON > HL7)
+
+The FHIR Specimen resource is mapped to a HL7 Compound Statement with a code of `123038009` (specimen (specimen))  
+
+| Mapped to (XML HL7 CompoundStatement element)             | Mapped from (JSON FHIR / other source )                                                                                                                                                                                                                                                          |
+|-----------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| id\[0] [@root]                                            | Unique ID generated by the adaptor                                                                                                                                                                                                                                                               |
+| code [@code]                                              | fixed value = `"123038009"`                                                                                                                                                                                                                                                                      |
+| code [@codeSystem]                                        | fixed value = `"2.16.840.1.113883.2.1.3.2.4.15"`                                                                                                                                                                                                                                                 |
+| code [@displayName]                                       | fixed value = `"specimen (specimen)"`                                                                                                                                                                                                                                                            |
+| statusCode [@code]                                        | fixed value = `"COMPLETE"`                                                                                                                                                                                                                                                                       |
+| effectiveTime / center [@nullFlavor]                      | fixed value = `"NI"`                                                                                                                                                                                                                                                                             |
+| availabilityTime [@value]                                 | `DiagnosticReport.issued`                                                                                                                                                                                                                                                                        |
+| specimen / specimenRole / id\[0] [@root]                  | Unique ID generated by the adaptor                                                                                                                                                                                                                                                               |
+| specimen / specimenRole / id\[1] [@root]                  | fixed value = `"2.16.840.1.113883.2.1.4.5.2"` if `Specimen.accessionIdentifier` is present                                                                                                                                                                                                       |
+| specimen / specimenRole / id\[1] [@extension]             | `Specimen.accessionIdentifier.value`                                                                                                                                                                                                                                                             |
+| effectiveTime / center [@value]                           | `Specimen.collection.collectedDateTime` or else `Specimen.collection.collectePeriod.start` or else `Specimen.recievedTime`                                                                                                                                                                       | 
+| specimen / specimenRole / specimenSpecimenMaterial / desc | `Specimen.type.text` or else `Specimen.type.coding[0].extention[index].extension[index2].value` <sup>5</sup>                                                                                                                                                                                     |
+| component / NarrativeStatement                            | the mapped [specimen level narrative statement](#Specimen-Level-Narrative-Statements)                                                                                                                                                                                                            |
+| component / CompoundStatement                             | mapped from the [Test Group Header](../observations/README.md#Test-Group-Header-(JSON-FHIR->-XML-HL7)) or [Test Result](../observations/README.md#Test-Result-(JSON-FHIR->-XML-HL7)) Observations referenced in `DiagnosticReport.result` where `Observation.specimen` references the `Specimen` |
+
+<details>
+ <summary>Example XML</summary>
+
+```XML
+
+<CompoundStatement classCode="CLUSTER" moodCode="EVN">
+ <id root="D6930FE2-0417-448B-85FA-0ACA7284CBD0"/>
+ <code code="123038009" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="specimen (specimen)"/>
+ <statusCode code="COMPLETE"/>
+ <effectiveTime>
+  <center nullFlavor="NI"/>
+ </effectiveTime>
+ <availabilityTime value="20030628112300"/>
+ <specimen typeCode="SPC">
+  <specimenRole classCode="SPEC">
+   <id root="DB2E5F7D-B0D0-488A-825A-BE58D09953CF"/>
+   <id extension="C3179539H" root="2.16.840.1.113883.2.1.4.5.2"/>
+   <effectiveTime>
+    <center value="20030627000000"/>
+   </effectiveTime>
+   <specimenSpecimenMaterial classCode="MAT" determinerCode="INSTANCE">
+    <desc>Plasma</desc>
+   </specimenSpecimenMaterial>
+  </specimenRole>
+ </specimen>
+ <component contextConductionInd="true" typeCode="COMP">
+  <NarrativeStatement classCode="OBS" moodCode="EVN">
+   <id root="DF0FEFF0-32C1-4BB9-8DDD-76E2D13B5D0F"/>
+   <text mediaType="text/x-h7uk-pmip">CommentType:LAB SPECIMEN COMMENT(E271)
+    CommentDate:20030627000000
+
+    Quantity: 1750.000 mL
+    Received Date: 2003-06-27 18:24
+   </text>
+   <statusCode code="COMPLETE"/>
+   <availabilityTime value="20030628112300"/>
+  </NarrativeStatement>
+ </component>
+ <component contextConductionInd="true" typeCode="COMP">
+  <CompoundStatement classCode="BATTERY" moodCode="EVN">
+   
+   ...
+   
+  </CompoundStatement>
+ </component>
+</CompoundStatement>
+```
+</details>
+
+5. Where `extension[index].url` equals `"https://fhir.nhs.uk/STU3/StructureDefinition/Extension-coding-sctdescid"`, 
+`extension[index2].url` equals `"descriptionDisplay"` and `extension[index2].value` does not equal `Specimen.type.coding[0].display` 
+
+### Specimen Level Narrative Statements
+
+A Narrative Statement is created to preserve data from FHIR fields that have no direct mapping.
+
+| Mapped to (XML HL7 NarrativeStatement element) | Mapped from (JSON FHIR / other source ) |
+|------------------------------------------------|-----------------------------------------|
+| id [@root]                                     | Unique ID generated by the adaptor      |
+| text [@mediaType]                              | fixed value = `"text/x-h7uk-pmip"`      |
+| text                                           | EDIFACT comment, as described below     |
+| statusCode                                     | fixedValue = `"COMPLETE"`               |
+| availabilityTime [@value]                      | `DiagnosticReport.issued`               |
+
+#### Text Element Mapping
+
+Unlike a diagnostic report `CompoundStatement`, which can have multiple `NarrativeStatement` components, the Specimen 
+`CompoundStatement` has a single `NarrativeStatement`. The Specimen fields without a direct mapping are concatenated and
+seperated by newlines, before being inserted into the `text` element of the `NarrativeStatement` as an EDIFACT comment 
+(example in the XML above). The comment type of the EDIFACT comment is fixed to `LAB SPECIMEN COMMENT(E271)`.
+
+The fields / values mapped to the comment are as follows:
+
+- fixed value = `"EMPTY SPECIMEN"` if no Observations referenced in `DiagnosticReport.result` reference the `Specimen`.  
+- `Specimen.receivedTime` prepended with `"Received Date:"`
+- `Specimen.collection.extention[index].valueCodeableConcept` prepended with `"Fasting Status:"`
+- `Specimen.collection.extention[index].valueDuration` prepended with  `"Fasting Duration:"`
+- `Specimen.collection.quantity` prepended with `"Quantity:"`
+- `Specimen.collection.bodySite` prepended with `"Collection Site:"`
+- `Practitioner.name` where the Practitioner is referenced by `Specimen.collection.collector`, prepended with `"Collected By:"`
+- `Specimen.note` 
+
+## Further documentation
+
+[GP Connect Diagnostic report documentation](https://developer.nhs.uk/apis/gpconnect-1-6-0/accessrecord_structured_development_DiagnosticReport.html)
+
+[GP Connect Specimen documentation](https://developer.nhs.uk/apis/gpconnect-1-6-0/accessrecord_structured_development_specimen.html)
+
+[GP Connect Investigations Guidance](https://developer.nhs.uk/apis/gpconnect-1-6-0/accessrecord_structured_development_pathology_guidance.html)
+
+[MIM 4.2.00](https://data.developer.nhs.uk/dms/mim/4.2.00/Index.htm) 


### PR DESCRIPTION
## Mapping Classes

### PS Adaptor

#### Diagnostic Report
https://github.com/NHSDigital/nia-patient-switching-standard-adaptor/blob/main/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/diagnosticreport/DiagnosticReportMapper.java

#### Specimen
https://github.com/NHSDigital/nia-patient-switching-standard-adaptor/blob/main/gp2gp-translator/src/main/java/uk/nhs/adaptors/pss/translator/mapper/diagnosticreport/SpecimenMapper.java

### GP2GP Adaptor

#### Diagnostic report
https://github.com/nhsconnect/integration-adaptor-gp2gp/blob/main/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/diagnosticreport/DiagnosticReportMapper.java

#### Specimen
https://github.com/nhsconnect/integration-adaptor-gp2gp/blob/main/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/diagnosticreport/SpecimenMapper.java