### PR TITLE
Create consistent layout for the further documentation section

### DIFF
--- a/allergy intolerances/README.md
+++ b/allergy intolerances/README.md
@@ -181,6 +181,6 @@ An Allergy Intolerance is mapped to a CompoundStatement with inner ObservationSt
 </details>
 
 ## Further documentation
-[GP Connect Allergy Intolerance](https://developer.nhs.uk/apis/gpconnect-1-6-0/accessrecord_structured_development_allergyintolerance.html)
 
-[MIM 4.2.00](https://data.developer.nhs.uk/dms/mim/4.2.00/Index.htm) 
+- [GP Connect Allergy Intolerance](https://developer.nhs.uk/apis/gpconnect-1-6-0/accessrecord_structured_development_allergyintolerance.html)
+- [MIM 4.2.00](https://data.developer.nhs.uk/dms/mim/4.2.00/Index.htm) 

--- a/conditions/README.md
+++ b/conditions/README.md
@@ -352,6 +352,6 @@ is SNOMED CT (`"http://snomed.info/sct"`).
 
 ## Further documentation
 
-[Problems guidance](https://developer.nhs.uk/apis/gpconnect-1-6-0/accessrecord_structured_development_problems_guidance.html)
-[FHIR Condition](https://developer.nhs.uk/apis/gpconnect-1-6-0/accessrecord_structured_problems.html)
-[MIM 4.2.00](https://data.developer.nhs.uk/dms/mim/4.2.00/Index.htm) 
+- [Problems guidance](https://developer.nhs.uk/apis/gpconnect-1-6-0/accessrecord_structured_development_problems_guidance.html)
+- [GP Connect ProblemHeader (Condition)](https://developer.nhs.uk/apis/gpconnect-1-6-0/accessrecord_structured_problems.html)
+- [MIM 4.2.00](https://data.developer.nhs.uk/dms/mim/4.2.00/Index.htm) 

--- a/diagnostic reports/README.md
+++ b/diagnostic reports/README.md
@@ -369,10 +369,7 @@ is referenced by `Specimen.collection.collector`, prepended with `"Collected By:
 
 ## Further documentation
 
-[GP Connect Diagnostic report documentation](https://developer.nhs.uk/apis/gpconnect-1-6-0/accessrecord_structured_development_DiagnosticReport.html)
-
-[GP Connect Specimen documentation](https://developer.nhs.uk/apis/gpconnect-1-6-0/accessrecord_structured_development_specimen.html)
-
-[GP Connect Investigations Guidance](https://developer.nhs.uk/apis/gpconnect-1-6-0/accessrecord_structured_development_pathology_guidance.html)
-
-[MIM 4.2.00](https://data.developer.nhs.uk/dms/mim/4.2.00/Index.htm) 
+- [GP Connect Diagnostic report documentation](https://developer.nhs.uk/apis/gpconnect-1-6-0/accessrecord_structured_development_DiagnosticReport.html)
+- [GP Connect Specimen documentation](https://developer.nhs.uk/apis/gpconnect-1-6-0/accessrecord_structured_development_specimen.html)
+- [GP Connect Investigations Guidance](https://developer.nhs.uk/apis/gpconnect-1-6-0/accessrecord_structured_development_pathology_guidance.html)
+- [MIM 4.2.00](https://data.developer.nhs.uk/dms/mim/4.2.00/Index.htm) 

--- a/document references/README.md
+++ b/document references/README.md
@@ -169,6 +169,6 @@ Where:
 - `{{conversationID}}` = the conversation ID of the migration
 
 ## Further documentation
-[GP Connect Document Reference](https://developer.nhs.uk/apis/gpconnect-1-6-0/access_documents_development_documentreference.html)
 
-[MIM 4.2.00](https://data.developer.nhs.uk/dms/mim/4.2.00/Index.htm) 
+- [GP Connect DocumentReference](https://developer.nhs.uk/apis/gpconnect-1-6-0/access_documents_development_documentreference.html)
+- [MIM 4.2.00](https://data.developer.nhs.uk/dms/mim/4.2.00/Index.htm) 

--- a/encounters/README.md
+++ b/encounters/README.md
@@ -190,8 +190,6 @@ then that code and display name is used. Otherwise, the SNOMED code `24591000000
 
 ## Further documentation
 
-[GP Connect Encounter](https://developer.nhs.uk/apis/gpconnect-1-6-0/accessrecord_structured_development_encounter.html)
-
-[MIM 4.2.00](https://data.developer.nhs.uk/dms/mim/4.2.00/Index.htm) 
-
-[EHR Composition Name Vocabulary](https://data.developer.nhs.uk/dms/mim/6.3.01/Vocabulary/EhrCompositionName.htm)
+- [GP Connect Encounter](https://developer.nhs.uk/apis/gpconnect-1-6-0/accessrecord_structured_development_encounter.html)
+- [MIM 4.2.00](https://data.developer.nhs.uk/dms/mim/4.2.00/Index.htm)
+- [EHR Composition Name Vocabulary](https://data.developer.nhs.uk/dms/mim/6.3.01/Vocabulary/EhrCompositionName.htm)

--- a/immunisations/README.md
+++ b/immunisations/README.md
@@ -165,5 +165,5 @@ An Immunization is primarily mapped from an Observation Statement.
 
 ## Further documentation
 
-[GP Connect Immunisation](https://developer.nhs.uk/apis/gpconnect-1-6-0/accessrecord_structured_development_immunization.html)
-[MIM 4.2.00](https://data.developer.nhs.uk/dms/mim/4.2.00/Index.htm)
+- [GP Connect Immunisation](https://developer.nhs.uk/apis/gpconnect-1-6-0/accessrecord_structured_development_immunization.html)
+- [MIM 4.2.00](https://data.developer.nhs.uk/dms/mim/4.2.00/Index.htm)

--- a/list/LIST_CONSULTATION_README.md
+++ b/list/LIST_CONSULTATION_README.md
@@ -128,6 +128,6 @@ A `List (Consultation)` does not generate its own XML section but instead is use
 </details>
 
 ## Further documentation
-[GP Connect List](https://developer.nhs.uk/apis/gpconnect-1-6-0/accessrecord_structured_development_list_consultation.html#list-consultation)
 
-[MIM 4.2.00](https://data.developer.nhs.uk/dms/mim/4.2.00/Index.htm) 
+- [GP Connect List](https://developer.nhs.uk/apis/gpconnect-1-6-0/accessrecord_structured_development_list_consultation.html#list-consultation)
+- [MIM 4.2.00](https://data.developer.nhs.uk/dms/mim/4.2.00/Index.htm) 

--- a/list/LIST_HEADING_README.md
+++ b/list/LIST_HEADING_README.md
@@ -158,6 +158,6 @@ Mapped from a `resource` with a type of `list` where `list.code.coding[0].code` 
 </details>
 
 ## Further documentation
-[GP Connect List](https://developer.nhs.uk/apis/gpconnect-1-6-0/accessrecord_structured_development_list_consultation.html#list-heading)
 
-[MIM 4.2.00](https://data.developer.nhs.uk/dms/mim/4.2.00/Index.htm) 
+- [GP Connect List](https://developer.nhs.uk/apis/gpconnect-1-6-0/accessrecord_structured_development_list_consultation.html#list-heading)
+- [MIM 4.2.00](https://data.developer.nhs.uk/dms/mim/4.2.00/Index.htm) 

--- a/list/LIST_TOPIC_README.md
+++ b/list/LIST_TOPIC_README.md
@@ -260,6 +260,6 @@ Mapped from a `resource` with a type of `list` where `list.code.coding[0].code` 
 </details>
 
 ## Further documentation
-[GP Connect List](https://developer.nhs.uk/apis/gpconnect-1-6-0/accessrecord_structured_development_list_consultation.html#list-topic)
 
-[MIM 4.2.00](https://data.developer.nhs.uk/dms/mim/4.2.00/Index.htm) 
+- [GP Connect List](https://developer.nhs.uk/apis/gpconnect-1-6-0/accessrecord_structured_development_list_consultation.html#list-topic)
+- [MIM 4.2.00](https://data.developer.nhs.uk/dms/mim/4.2.00/Index.htm) 

--- a/list/README.md
+++ b/list/README.md
@@ -7,7 +7,7 @@ A `List` structure is used to represent structured consulations and can be mappe
 3. [List (Heading)](./LIST_HEADING_README.md)
 
 ## Further documentation
-[GP Connect List ](https://developer.nhs.uk/apis/gpconnect-1-6-0/accessrecord_structured_development_list_consultation.html)
 
-[MIM 4.2.00](https://data.developer.nhs.uk/dms/mim/4.2.00/Index.htm) 
+- [GP Connect List](https://developer.nhs.uk/apis/gpconnect-1-6-0/accessrecord_structured_development_list_consultation.html)
+- [MIM 4.2.00](https://data.developer.nhs.uk/dms/mim/4.2.00/Index.htm) 
 

--- a/locations/README.md
+++ b/locations/README.md
@@ -98,5 +98,5 @@ An Encounter with linked Location is mapped to a composition containing a locati
 
 ## Further documentation
 
-[FHIR specification](https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Location-1)
-[MIM 4.2.00](https://data.developer.nhs.uk/dms/mim/4.2.00/Index.htm) 
+- [FHIR specification](https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Location-1)
+- [MIM 4.2.00](https://data.developer.nhs.uk/dms/mim/4.2.00/Index.htm)

--- a/medication requests/README.md
+++ b/medication requests/README.md
@@ -305,6 +305,5 @@ For details of mapping for both `PLAN` and `ORDER`, see the JSON FHIR > XML HL7 
 
 ## Further documentation
 
-[GP Connect MedicationRequest](https://developer.nhs.uk/apis/gpconnect-1-6-0/accessrecord_structured_development_medicationrequest.html)
-
-[MIM 4.2.00](https://data.developer.nhs.uk/dms/mim/4.2.00/Index.htm) 
+- [GP Connect MedicationRequest](https://developer.nhs.uk/apis/gpconnect-1-6-0/accessrecord_structured_development_medicationrequest.html)
+- [MIM 4.2.00](https://data.developer.nhs.uk/dms/mim/4.2.00/Index.htm)

--- a/medication statements/README.md
+++ b/medication statements/README.md
@@ -430,6 +430,5 @@ This is mapped from `Medication.code` where `Medication` is the resource to refe
 
 ## Further documentation
 
-[GP Connect Medication Statement](https://developer.nhs.uk/apis/gpconnect-1-6-0/accessrecord_structured_development_medicationstatement.html)
-
-[MIM 4.2.00](https://data.developer.nhs.uk/dms/mim/4.2.00/Index.htm) 
+- [GP Connect MedicationStatement](https://developer.nhs.uk/apis/gpconnect-1-6-0/accessrecord_structured_development_medicationstatement.html)
+- [MIM 4.2.00](https://data.developer.nhs.uk/dms/mim/4.2.00/Index.htm)

--- a/medications/README.md
+++ b/medications/README.md
@@ -51,6 +51,5 @@ This is covered and detailed in the mapping for [MedicationStatement](../medicat
 
 ## Further documentation
 
-[GP Connect Medication](https://developer.nhs.uk/apis/gpconnect-1-6-0/accessrecord_structured_development_medication.html)
-
-[MIM 4.2.00](https://data.developer.nhs.uk/dms/mim/4.2.00/Index.htm)
+- [GP Connect Medication](https://developer.nhs.uk/apis/gpconnect-1-6-0/accessrecord_structured_development_medication.html)
+- [MIM 4.2.00](https://data.developer.nhs.uk/dms/mim/4.2.00/Index.htm)

--- a/observations/README.md
+++ b/observations/README.md
@@ -1420,22 +1420,17 @@ CommentDate:20100326134545
 
 ### GP Connect Uncategorised data
 
-[GP Connect uncategorised data guidance](https://developer.nhs.uk/apis/gpconnect-1-6-0/accessrecord_structured_development_uncategorisedData_guidance.html)
-
-[GP Connect Observation - uncategorised data](https://developer.nhs.uk/apis/gpconnect-1-6-0/accessrecord_structured_development_observation_uncategorisedData.html)
-
-[GP Connect Observation - blood pressure](https://developer.nhs.uk/apis/gpconnect-1-6-0/accessrecord_structured_development_observation_bloodPressure.html)
+- [GP Connect uncategorised data guidance](https://developer.nhs.uk/apis/gpconnect-1-6-0/accessrecord_structured_development_uncategorisedData_guidance.html)
+- [GP Connect Observation - uncategorised data](https://developer.nhs.uk/apis/gpconnect-1-6-0/accessrecord_structured_development_observation_uncategorisedData.html)
+- [GP Connect Observation - blood pressure](https://developer.nhs.uk/apis/gpconnect-1-6-0/accessrecord_structured_development_observation_bloodPressure.html)
 
 ### GP Connect Investigations
 
-[GP Connect Investigations guidance](https://developer.nhs.uk/apis/gpconnect-1-6-0/accessrecord_structured_development_pathology_guidance.html)
-
-[GP Connect Observation - test group header](https://developer.nhs.uk/apis/gpconnect-1-6-0/accessrecord_structured_development_observation_testGroup.html)
-
-[GP Connect Observation - test result](https://developer.nhs.uk/apis/gpconnect-1-6-0/accessrecord_structured_development_observation_testResult.html)
-
-[GP Connect Observation - filing comment](https://developer.nhs.uk/apis/gpconnect-1-6-0/accessrecord_structured_development_observation_filingComments.html)
+- [GP Connect Investigations guidance](https://developer.nhs.uk/apis/gpconnect-1-6-0/accessrecord_structured_development_pathology_guidance.html)
+- [GP Connect Observation - test group header](https://developer.nhs.uk/apis/gpconnect-1-6-0/accessrecord_structured_development_observation_testGroup.html)
+- [GP Connect Observation - test result](https://developer.nhs.uk/apis/gpconnect-1-6-0/accessrecord_structured_development_observation_testResult.html)
+- [GP Connect Observation - filing comment](https://developer.nhs.uk/apis/gpconnect-1-6-0/accessrecord_structured_development_observation_filingComments.html)
 
 ### HL7v3 MIM
 
-[MIM 4.2.00](https://data.developer.nhs.uk/dms/mim/4.2.00/Index.htm)
+- [MIM 4.2.00](https://data.developer.nhs.uk/dms/mim/4.2.00/Index.htm)

--- a/organisations/README.md
+++ b/organisations/README.md
@@ -289,6 +289,6 @@ was given to the Organisation as a performer.
 3. The first instance of `Organization.telecom` where `Organization.telecom.system.display` is equal to `"phone"` and `Organization.telecom.use` is equal to `"work"`
 
 ## Further documentation
-[GP Connect Organisation structure definition](https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Organization-1)
 
-[MIM 4.2.00](https://data.developer.nhs.uk/dms/mim/4.2.00/Index.htm)
+- [GP Connect Organisation structure definition](https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Organization-1)
+- [MIM 4.2.00](https://data.developer.nhs.uk/dms/mim/4.2.00/Index.htm)

--- a/patient/README.md
+++ b/patient/README.md
@@ -101,5 +101,5 @@ A Patient record is inserted into the EhrExtracts recordTarget.
 
 ## Further documentation
 
-[FHIR Patient](https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Patient-1)
-[MIM 4.2.00](https://data.developer.nhs.uk/dms/mim/4.2.00/Index.htm) 
+- [FHIR Patient](https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Patient-1)
+- [MIM 4.2.00](https://data.developer.nhs.uk/dms/mim/4.2.00/Index.htm)

--- a/practioners/README.md
+++ b/practioners/README.md
@@ -193,8 +193,7 @@ A Practitioner is mapped to an `Agent` with a role of `AgentPerson`.
 </details>
 
 ## Further documentation
-[GP Connect Practitioner structure definition](https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Practitioner-1)
 
-[GP Connect PractitionerRole structure definition](https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-PractitionerRole-1)
-
-[MIM 4.2.00](https://data.developer.nhs.uk/dms/mim/4.2.00/Index.htm)
+- [GP Connect Practitioner structure definition](https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Practitioner-1)
+- [GP Connect PractitionerRole structure definition](https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-PractitionerRole-1)
+- [MIM 4.2.00](https://data.developer.nhs.uk/dms/mim/4.2.00/Index.htm)

--- a/procedure requests/README.md
+++ b/procedure requests/README.md
@@ -131,5 +131,5 @@ A Procedure Request is mapped to a Plan Statement.
 
 ## Further documentation
 
-[GP Connect Procedure Request](https://developer.nhs.uk/apis/gpconnect-1-6-0/accessrecord_structured_development_ProcedureRequest.html)
-[MIM 4.2.00](https://data.developer.nhs.uk/dms/mim/4.2.00/Index.htm) 
+- [GP Connect ProcedureRequest](https://developer.nhs.uk/apis/gpconnect-1-6-0/accessrecord_structured_development_ProcedureRequest.html)
+- [MIM 4.2.00](https://data.developer.nhs.uk/dms/mim/4.2.00/Index.htm) 

--- a/referral requests/README.md
+++ b/referral requests/README.md
@@ -171,6 +171,6 @@ A ReferralRequest is mapped to a RequestStatement
 </details>
 
 ## Further documentation
-[GP Connect Referral Request](https://developer.nhs.uk/apis/gpconnect-1-6-0/accessrecord_structured_development_referralrequest.html)
 
-[MIM 4.2.00](https://data.developer.nhs.uk/dms/mim/4.2.00/Index.htm) 
+- [GP Connect ReferralRequest](https://developer.nhs.uk/apis/gpconnect-1-6-0/accessrecord_structured_development_referralrequest.html)
+- [MIM 4.2.00](https://data.developer.nhs.uk/dms/mim/4.2.00/Index.htm)


### PR DESCRIPTION
Previously some pages were displaying links side by side which was unclear.