### PR TITLE
NIAD-2972: update Referral Request Priority mapping

### DIFF
--- a/referral requests/README.md
+++ b/referral requests/README.md
@@ -4,21 +4,21 @@
 
 A Referral Request is mapped from a `RequestStatement`
 
-| Mapped to (JSON FHIR Referral Request field) | Mapped from (XML HL7 / other source)                                                                                                                                                                |
-|----------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| id                                           | `RequestStatement / id [@root]`                                                                                                                                                                     |
-| meta.profile\[0]                             | fixed value = `"https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-ReferralRequest-1"`                                                                                                    |
-| identifier                                   | `"https://PSSAdaptor/{{losingOdsCode}}"` - where the `{{losingOdsCode}}` is the ODS code of the losing practice                                                                                     |
-| status                                       | fixed value = `unknown`                                                                                                                                                                             |
-| intent                                       | fixed value = `order`                                                                                                                                                                               |
-| priority                                     | `RequestStatement / priorityCode [@code]` or `CompoundStatement / priorityCode [@code]` and mapped to string values of `Routine`, `Urgent`, or `ASAP`. If not present in either location is omitted |
-| subject                                      | reference to the mapped [Patient](../patient/README.md)                                                                                                                                             |
-| context                                      | reference to the mapped [Encounter](../encounters/README.md)                                                                                                                                        |
-| authoredOn                                   | `RequestStatement / availabilityTime [@value]`                                                                                                                                                      |
-| requester.agent                              | reference to mapped [Practitioner](../practitioners/README.md) from `RequestStatement / Participent / agentRef` or `Composition / Participent / agentRef`                                           |
-| recipient                                    | reference to mapped [Practitioner](../practitioners/README.md) from `RequestStatement / responsibleParty / agentRef`                                                                                |
-| reasonCode                                   | mapped CodeableConcept from `RequestStatement / code` <sup>1</sup> as described in the XML > FHIR section of [Codeable Concept](../codeable%20concept/README.md)                                    |
-| note                                         | mapped Annotation from `RequestStatement / text` & `RequestStatement / priorityCode` & `RequestStatement / priorityCode`                                                                            |
+| Mapped to (JSON FHIR Referral Request field) | Mapped from (XML HL7 / other source)                                                                                                                             |
+|----------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| id                                           | `RequestStatement / id [@root]`                                                                                                                                  |
+| meta.profile\[0]                             | fixed value = `"https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-ReferralRequest-1"`                                                                 |
+| identifier                                   | `"https://PSSAdaptor/{{losingOdsCode}}"` - where the `{{losingOdsCode}}` is the ODS code of the losing practice                                                  |
+| status                                       | fixed value = `unknown`                                                                                                                                          |
+| intent                                       | fixed value = `order`                                                                                                                                            |
+| priority                                     | `RequestStatement / priorityCode [@code]` and mapped to string values of `Routine`, `Urgent`, or `ASAP`. If not present then it is omitted.                      |
+| subject                                      | reference to the mapped [Patient](../patient/README.md)                                                                                                          |
+| context                                      | reference to the mapped [Encounter](../encounters/README.md)                                                                                                     |
+| authoredOn                                   | `RequestStatement / availabilityTime [@value]`                                                                                                                   |
+| requester.agent                              | reference to mapped [Practitioner](../practitioners/README.md) from `RequestStatement / Participent / agentRef` or `Composition / Participent / agentRef`        |
+| recipient                                    | reference to mapped [Practitioner](../practitioners/README.md) from `RequestStatement / responsibleParty / agentRef`                                             |
+| reasonCode                                   | mapped CodeableConcept from `RequestStatement / code` <sup>1</sup> as described in the XML > FHIR section of [Codeable Concept](../codeable%20concept/README.md) |
+| note                                         | mapped Annotation from `RequestStatement / text` & `RequestStatement / priorityCode` & `RequestStatement / priorityCode`                                         |
 
 1.  If the SNOMED code is not found then a `Transfer-degraded referral` code is inserted instead (96431000000106)
 


### PR DESCRIPTION
The mapping for the referral priority HL7 > FHIR was incorrect. It was never mapped from the compound statement. 